### PR TITLE
Improved performace and correctness for raster union

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+# pyenv stuff
+.python-version
+
+# install from source
+georasters.egg-info/
+**/__pycache__/
+
+# general python
+*.pyc
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,8 +3,8 @@ pandas
 docopt
 GDAL
 Cython
-git+https://github.com/jswhit/pyproj.git
-git+https://github.com/scikit-image/scikit-image.git
+pyproj
+scikit-image
 matplotlib
 coverage
 fiona


### PR DESCRIPTION
Moved some stuff around and made some performance improvements to the merge functionality. There were a lot of extra array copies and instances where larger data types than needed were used. 

The main improvements were:
- selecting the correct numpy `dtype` for the arrays that were created
- selecting a default no data value if there was none
- creating a pre-filled array with the no data value instead of multiplying it with an array of ones
- making the mask start out as an array of bools.

Testing done: Just on my own code, merging 24 rasters into a 43201x86401 array. It just barely works now instead of crashing because it was not able to allocate the arrays.