### PR TITLE
fixed positional arguements not being passed on subset

### DIFF
--- a/georasters/georasters.py
+++ b/georasters/georasters.py
@@ -345,7 +345,10 @@ class GeoRaster(object):
         geot[0] += indx[0].start*geot[1]
         geot[3] += indx[1].start*geot[-1]
         geot = tuple(geot)
-        return GeoRaster(rast, geot, nodata, proj, datatype)
+        return GeoRaster(rast, geot,
+                         nodata_value=nodata,
+                         projection=proj,
+                         datatype=datatype)
 
     def __getslice__(self, i, j):
         return self.raster.__getslice__(i, j)


### PR DESCRIPTION
Currently, doing something like this on master:

```
graster = gr.GeoRaster(dest.GetRasterBand(1).ReadAsArray(),
                                      dest.GetGeoTransform(),
                                      projection = wgs84,
                                      datatype=gdal.GDT_Float32)
```
...and subsetting:

`sub = graster[100:200,100:200]`

yields the following:

```
In [12]: graster.datatype
Out [12]: 6

In [13]: sub.datatype
Out [13]: 
```

...and the NoneType screws with all of the other georasters functions like `to_tiff` that depend on a functional projection or datatype attribute to work.